### PR TITLE
Added missing 'else' for the incentive RPC method.

### DIFF
--- a/src/rpc_connection.cpp
+++ b/src/rpc_connection.cpp
@@ -589,7 +589,7 @@ bool rpc_connection::handle_json_rpc_request(
         {
             response = json_getdifficulty(request);
         }
-        if (request.method == "incentive")
+        else if (request.method == "incentive")
         {
             response = json_incentive(request);
         }


### PR DESCRIPTION
Fix: "method not found" for all method calls above the incentive one